### PR TITLE
Adding requirements.txt file and fixing regular expression for domain parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+-e git://github.com/carbonblack/cbapi.git#egg=cbapi&subdirectory=client_apis/python
+-e git://github.com/carbonblack/cbfeeds.git#egg=cbfeeds
+-e git://github.com/carbonblack/cb-integration.git#egg=cbint
+requests >= 2.7.0

--- a/src/cbinfoblox/syslog_server.py
+++ b/src/cbinfoblox/syslog_server.py
@@ -10,7 +10,7 @@ class SyslogServer(threading.Thread):
         self.worker_queue = worker_queue
         self.logger = logger
         self.format_string = \
-            re.compile('src=(\d+.\d+.\d+.\d+) .*rewrite ([a-zA-Z0-9][a-zA-Z0-9-]{1,61}[a-zA-Z0-9]\.[a-zA-Z]{2,})')
+            re.compile('src=(\d+.\d+.\d+.\d+) .*rewrite (?=.{1,254}$)((?:(?!\d+\.|-)[a-zA-Z0-9_\-]{1,63}(?<!-)\.)+(?:[a-zA-Z]{2,}))')
         threading.Thread.__init__(self)
 
     def run(self):


### PR DESCRIPTION
Original regex wasn't good enough... tested it here too:

http://pythex.org/

Example:

CEF:0|Infoblox|NIOS|7.2.1-293130|RPZ-QNAME|Local-Data|7|app=DNS dst=192.168.230.6 src=192.168.230.5 spt=54505 view=_default qtype=A msg="rpz QNAME Local-Data rewrite wutang.forever.com [A] via wutang.forever.com.test"
